### PR TITLE
Allows to select the project credentials to use

### DIFF
--- a/lib/kane/client.ex
+++ b/lib/kane/client.ex
@@ -32,9 +32,10 @@ defmodule Kane.Client do
 
   defp endpoint, do: Application.get_env(:kane, :endpoint, "https://pubsub.googleapis.com/v1")
   defp token_mod, do: Application.get_env(:kane, :token, Goth.Token)
+  def project_email, do: Application.get_env(:kane, :project_email)
 
   defp auth_header do
-    {:ok, token} = token_mod().for_scope(Kane.oauth_scope())
+    {:ok, token} = token_mod().for_scope({project_email(), Kane.oauth_scope()})
     {"Authorization", "#{token.type} #{token.token}"}
   end
 

--- a/lib/kane/message.ex
+++ b/lib/kane/message.ex
@@ -104,7 +104,7 @@ defmodule Kane.Message do
   defp path(%Topic{name: topic}), do: path(topic)
 
   defp path(topic) do
-    {:ok, project} = Goth.Config.get(:project_id)
+    {:ok, project} = Goth.Config.get(Kane.Client.project_email(), :project_id)
     "projects/#{project}/topics/#{Topic.strip!(topic)}:publish"
   end
 end

--- a/lib/kane/subscription.ex
+++ b/lib/kane/subscription.ex
@@ -107,7 +107,7 @@ defmodule Kane.Subscription do
   end
 
   defp project do
-    {:ok, project} = Goth.Config.get(:project_id)
+    {:ok, project} = Goth.Config.get(Kane.Client.project_email(), :project_id)
     project
   end
 
@@ -127,7 +127,7 @@ defmodule Kane.Subscription do
   def full_name(%__MODULE__{name: name}), do: full_name(name)
 
   def full_name(name) do
-    {:ok, project} = Goth.Config.get(:project_id)
+    {:ok, project} = Goth.Config.get(Kane.Client.project_email(), :project_id)
     "projects/#{project}/subscriptions/#{name}"
   end
 

--- a/lib/kane/topic.ex
+++ b/lib/kane/topic.ex
@@ -95,7 +95,7 @@ defmodule Kane.Topic do
   defp with_name(name), do: %__MODULE__{name: strip!(name)}
 
   defp project do
-    {:ok, id} = Goth.Config.get(:project_id)
+    {:ok, id} = Goth.Config.get(Kane.Client.project_email(), :project_id)
     id
   end
 


### PR DESCRIPTION
Allows to select the project credentials to use passing the project email as identifier, given that we use multiple credentials